### PR TITLE
transaction_history 추가 외 1건

### DIFF
--- a/pybithumb/__init__.py
+++ b/pybithumb/__init__.py
@@ -20,3 +20,7 @@ def get_current_price(order_currency, payment_currency="KRW"):
 
 def get_orderbook(order_currency, payment_currency="KRW", limit=5):
     return Bithumb.get_orderbook(order_currency, payment_currency, limit)
+
+
+def get_transaction_history(order_currency, payment_currency="KRW", limit=20):
+    return Bithumb.get_transaction_history(order_currency, payment_currency, limit)

--- a/pybithumb/client.py
+++ b/pybithumb/client.py
@@ -113,7 +113,7 @@ class Bithumb:
         """
         resp = None
         try:
-            limit = min(limit, 20)
+            limit = min(limit, 30)
             resp = PublicApi.orderbook(order_currency, payment_currency, limit)
             data = resp['data']
             for idx in range(len(data['bids'])) :
@@ -134,6 +134,22 @@ class Bithumb:
             data['date'] = datetime.datetime.fromtimestamp(int(data['date']) / 1e3)
             return data
         except Exception:
+            return None
+
+    @staticmethod
+    def get_transaction_history(order_currency, payment_currency="KRW", limit=20):
+        resp = None
+        try:
+            limit = min(limit, 100)
+            resp = PublicApi.transaction_history(order_currency, payment_currency, limit)
+            data = resp['data']
+            for idx in range(len(data)):
+                data[idx]['units_traded'] = float(data[idx]['units_traded'])
+                data[idx]['price'] = float(data[idx]['price'])
+                data[idx]['total'] = float(data[idx]['total'])
+            return data
+        except Exception as e:
+            print (e)
             return None
 
     def get_trading_fee(self, order_currency, payment_currency="KRW"):

--- a/pybithumb/core.py
+++ b/pybithumb/core.py
@@ -15,9 +15,10 @@ class PublicApi:
         return BithumbHttp().get(uri)
 
     @staticmethod
-    def transaction_history(order_currency, payment_currency="KRW"):
-        uri = "/public/transaction_history/{}_{}".format(order_currency,
-                                                    payment_currency)
+    def transaction_history(order_currency, payment_currency="KRW", limit=20):
+        uri = "/public/transaction_history/{}_{}?count={}".format(order_currency,
+                                                    payment_currency,
+                                                    limit)
         return BithumbHttp().get(uri)
 
     @staticmethod


### PR DESCRIPTION
- transaction_history 실제로 사용 가능하게 static 메서드로 추가
- orderbook 조회 최대치 20에서 30(bithumb이 제공하는 최대치)으로 변경